### PR TITLE
Automatic update of coverlet.msbuild to 2.9.0

### DIFF
--- a/docs/s/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
+++ b/docs/s/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
@@ -10,7 +10,7 @@
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/docs/s/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/docs/s/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/docs/s/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
+++ b/docs/s/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
    <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/docs/s/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/docs/s/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/docs/s/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/docs/s/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -7,7 +7,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/docs/s/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/docs/s/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -4,7 +4,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/docs/s/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/docs/s/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -4,7 +4,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/docs/s/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/docs/s/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -7,7 +7,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRulesForTests.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/docs/s/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
+++ b/docs/s/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+    <PackageReference Include="coverlet.msbuild" Version="2.9.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
NuKeeper has generated a minor update of `coverlet.msbuild` to `2.9.0` from `2.8.1`
`coverlet.msbuild 2.9.0` was published at `2020-05-30T09:30:58Z`, 13 days ago

9 project updates:
Updated `docs\s\NuKeeper.Abstractions.Tests\NuKeeper.Abstractions.Tests.csproj` to `coverlet.msbuild` `2.9.0` from `2.8.1`
Updated `docs\s\Nukeeper.AzureDevOps.Tests\Nukeeper.AzureDevOps.Tests.csproj` to `coverlet.msbuild` `2.9.0` from `2.8.1`
Updated `docs\s\NuKeeper.Gitea.Tests\NuKeeper.Gitea.Tests.csproj` to `coverlet.msbuild` `2.9.0` from `2.8.1`
Updated `docs\s\NuKeeper.GitHub.Tests\NuKeeper.GitHub.Tests.csproj` to `coverlet.msbuild` `2.9.0` from `2.8.1`
Updated `docs\s\NuKeeper.Gitlab.Tests\NuKeeper.Gitlab.Tests.csproj` to `coverlet.msbuild` `2.9.0` from `2.8.1`
Updated `docs\s\NuKeeper.Inspection.Tests\NuKeeper.Inspection.Tests.csproj` to `coverlet.msbuild` `2.9.0` from `2.8.1`
Updated `docs\s\NuKeeper.Integration.Tests\NuKeeper.Integration.Tests.csproj` to `coverlet.msbuild` `2.9.0` from `2.8.1`
Updated `docs\s\NuKeeper.Tests\NuKeeper.Tests.csproj` to `coverlet.msbuild` `2.9.0` from `2.8.1`
Updated `docs\s\NuKeeper.Update.Tests\NuKeeper.Update.Tests.csproj` to `coverlet.msbuild` `2.9.0` from `2.8.1`

[coverlet.msbuild 2.9.0 on NuGet.org](https://www.nuget.org/packages/coverlet.msbuild/2.9.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
