### PR TITLE
Automatic update of NuGet.Protocol to 5.6.0

### DIFF
--- a/docs/s/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
+++ b/docs/s/NuKeeper.Abstractions/NuKeeper.Abstractions.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.5.1" />
+    <PackageReference Include="NuGet.Protocol" Version="5.6.0" />
   </ItemGroup>
 
 </Project>

--- a/docs/s/NuKeeper.Inspection/NuKeeper.Inspection.csproj
+++ b/docs/s/NuKeeper.Inspection/NuKeeper.Inspection.csproj
@@ -6,7 +6,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NuGet.Protocol" Version="5.5.1" />
+    <PackageReference Include="NuGet.Protocol" Version="5.6.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `NuGet.Protocol` to `5.6.0` from `5.5.1`
`NuGet.Protocol 5.6.0` was published at `2020-05-20T22:31:36Z`, 22 days ago

2 project updates:
Updated `docs\s\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj` to `NuGet.Protocol` `5.6.0` from `5.5.1`
Updated `docs\s\NuKeeper.Inspection\NuKeeper.Inspection.csproj` to `NuGet.Protocol` `5.6.0` from `5.5.1`

[NuGet.Protocol 5.6.0 on NuGet.org](https://www.nuget.org/packages/NuGet.Protocol/5.6.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
