### PR TITLE
Automatic update of NSubstitute to 4.2.2

### DIFF
--- a/docs/s/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
+++ b/docs/s/NuKeeper.Abstractions.Tests/NuKeeper.Abstractions.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/docs/s/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
+++ b/docs/s/NuKeeper.Git.Tests/NuKeeper.Git.Tests.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/docs/s/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
+++ b/docs/s/NuKeeper.GitHub.Tests/NuKeeper.GitHub.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/docs/s/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
+++ b/docs/s/NuKeeper.Gitea.Tests/NuKeeper.Gitea.Tests.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/docs/s/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
+++ b/docs/s/NuKeeper.Gitlab.Tests/NuKeeper.Gitlab.Tests.csproj
@@ -16,7 +16,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/docs/s/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
+++ b/docs/s/NuKeeper.Inspection.Tests/NuKeeper.Inspection.Tests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/docs/s/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
+++ b/docs/s/NuKeeper.Integration.Tests/NuKeeper.Integration.Tests.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/docs/s/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/docs/s/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -9,7 +9,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/docs/s/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
+++ b/docs/s/NuKeeper.Update.Tests/NuKeeper.Update.Tests.csproj
@@ -12,7 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/docs/s/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
+++ b/docs/s/Nukeeper.AzureDevOps.Tests/Nukeeper.AzureDevOps.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a patch update of `NSubstitute` to `4.2.2` from `4.2.1`
`NSubstitute 4.2.2` was published at `2020-06-13T05:51:58Z`, 7 days ago

10 project updates:
Updated `docs\s\NuKeeper.Abstractions.Tests\NuKeeper.Abstractions.Tests.csproj` to `NSubstitute` `4.2.2` from `4.2.1`
Updated `docs\s\Nukeeper.AzureDevOps.Tests\Nukeeper.AzureDevOps.Tests.csproj` to `NSubstitute` `4.2.2` from `4.2.1`
Updated `docs\s\NuKeeper.Git.Tests\NuKeeper.Git.Tests.csproj` to `NSubstitute` `4.2.2` from `4.2.1`
Updated `docs\s\NuKeeper.Gitea.Tests\NuKeeper.Gitea.Tests.csproj` to `NSubstitute` `4.2.2` from `4.2.1`
Updated `docs\s\NuKeeper.GitHub.Tests\NuKeeper.GitHub.Tests.csproj` to `NSubstitute` `4.2.2` from `4.2.1`
Updated `docs\s\NuKeeper.Gitlab.Tests\NuKeeper.Gitlab.Tests.csproj` to `NSubstitute` `4.2.2` from `4.2.1`
Updated `docs\s\NuKeeper.Inspection.Tests\NuKeeper.Inspection.Tests.csproj` to `NSubstitute` `4.2.2` from `4.2.1`
Updated `docs\s\NuKeeper.Integration.Tests\NuKeeper.Integration.Tests.csproj` to `NSubstitute` `4.2.2` from `4.2.1`
Updated `docs\s\NuKeeper.Tests\NuKeeper.Tests.csproj` to `NSubstitute` `4.2.2` from `4.2.1`
Updated `docs\s\NuKeeper.Update.Tests\NuKeeper.Update.Tests.csproj` to `NSubstitute` `4.2.2` from `4.2.1`

[NSubstitute 4.2.2 on NuGet.org](https://www.nuget.org/packages/NSubstitute/4.2.2)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
