### PR TITLE
Automatic update of SimpleInjector to 5.1.0

### DIFF
--- a/docs/s/NuKeeper.Tests/NuKeeper.Tests.csproj
+++ b/docs/s/NuKeeper.Tests/NuKeeper.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="SimpleInjector" Version="5.0.3" />
+    <PackageReference Include="SimpleInjector" Version="5.1.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\NuKeeper.Abstractions\NuKeeper.Abstractions.csproj" />

--- a/docs/s/NuKeeper/NuKeeper.csproj
+++ b/docs/s/NuKeeper/NuKeeper.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="NuGet.Credentials" Version="5.7.0" />
-    <PackageReference Include="SimpleInjector" Version="5.0.3" />
+    <PackageReference Include="SimpleInjector" Version="5.1.0" />
     <PackageReference Include="SimpleInjector.Integration.ServiceCollection" Version="5.0.1" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
NuKeeper has generated a minor update of `SimpleInjector` to `5.1.0` from `5.0.3`
`SimpleInjector 5.1.0` was published at `2020-10-24T13:57:50Z`, 11 days ago

2 project updates:
Updated `docs\s\NuKeeper\NuKeeper.csproj` to `SimpleInjector` `5.1.0` from `5.0.3`
Updated `docs\s\NuKeeper.Tests\NuKeeper.Tests.csproj` to `SimpleInjector` `5.1.0` from `5.0.3`

[SimpleInjector 5.1.0 on NuGet.org](https://www.nuget.org/packages/SimpleInjector/5.1.0)


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
