### PR TITLE
Automatic update of Microsoft.Extensions.DependencyInjection to 5.0.0

### DIFF
--- a/docs/s/NuKeeper/NuKeeper.csproj
+++ b/docs/s/NuKeeper/NuKeeper.csproj
@@ -11,7 +11,7 @@
     <CodeAnalysisRuleSet>..\CodeAnalysisRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NuGet.CommandLine" Version="5.7.0">
       <!-- Warning! This needs to match TfmSpecificPackageFile lower down or packaging will fail -->


### PR DESCRIPTION
NuKeeper has generated a major update of `Microsoft.Extensions.DependencyInjection` to `5.0.0` from `3.1.8`
`Microsoft.Extensions.DependencyInjection 5.0.0` was published at `2020-10-27T05:44:53Z`, 8 days ago

1 project update:
Updated `docs\s\NuKeeper\NuKeeper.csproj` to `Microsoft.Extensions.DependencyInjection` `5.0.0` from `3.1.8`


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
